### PR TITLE
Add v3 fields funcs

### DIFF
--- a/v3/fields_funcs.go
+++ b/v3/fields_funcs.go
@@ -101,3 +101,16 @@ func EventFields(r Resource) map[string]string {
 	stringutil.MergeMapWithPrefix(fields, resource.Check.ObjectMeta.Labels, "event.labels.")
 	return fields
 }
+
+// EventFilterFields returns a set of fields that represent that resource
+func EventFilterFields(r Resource) map[string]string {
+	resource := r.(*corev2.EventFilter)
+	fields := map[string]string{
+		"filter.name":           resource.ObjectMeta.Name,
+		"filter.namespace":      resource.ObjectMeta.Namespace,
+		"filter.action":         resource.Action,
+		"filter.runtime_assets": strings.Join(resource.RuntimeAssets, ","),
+	}
+	stringutil.MergeMapWithPrefix(fields, resource.ObjectMeta.Labels, "filter.labels.")
+	return fields
+}

--- a/v3/fields_funcs.go
+++ b/v3/fields_funcs.go
@@ -114,3 +114,77 @@ func EventFilterFields(r Resource) map[string]string {
 	stringutil.MergeMapWithPrefix(fields, resource.ObjectMeta.Labels, "filter.labels.")
 	return fields
 }
+
+// HandlerFields returns a set of fields that represent that resource
+func HandlerFields(r Resource) map[string]string {
+	resource := r.(*corev2.Handler)
+	fields := map[string]string{
+		"handler.name":      resource.ObjectMeta.Name,
+		"handler.namespace": resource.ObjectMeta.Namespace,
+		"handler.filters":   strings.Join(resource.Filters, ","),
+		"handler.handlers":  strings.Join(resource.Handlers, ","),
+		"handler.mutator":   resource.Mutator,
+		"handler.type":      resource.Type,
+	}
+	stringutil.MergeMapWithPrefix(fields, resource.ObjectMeta.Labels, "handler.labels.")
+	return fields
+}
+
+// MutatorFields returns a set of fields that represent that resource
+func MutatorFields(r Resource) map[string]string {
+	resource := r.(*corev2.Mutator)
+	fields := map[string]string{
+		"mutator.name":           resource.ObjectMeta.Name,
+		"mutator.namespace":      resource.ObjectMeta.Namespace,
+		"mutator.runtime_assets": strings.Join(resource.RuntimeAssets, ","),
+	}
+	stringutil.MergeMapWithPrefix(fields, resource.ObjectMeta.Labels, "mutator.labels.")
+	return fields
+}
+
+// SilencedFields returns a set of fields that represent that resource
+func SilencedFields(r Resource) map[string]string {
+	resource := r.(*corev2.Silenced)
+	fields := map[string]string{
+		"silenced.name":              resource.ObjectMeta.Name,
+		"silenced.namespace":         resource.ObjectMeta.Namespace,
+		"silenced.check":             resource.Check,
+		"silenced.creator":           resource.Creator,
+		"silenced.expire_on_resolve": strconv.FormatBool(resource.ExpireOnResolve),
+		"silenced.subscription":      resource.Subscription,
+	}
+	stringutil.MergeMapWithPrefix(fields, resource.ObjectMeta.Labels, "silenced.labels.")
+	return fields
+}
+
+// HookConfigFields returns a set of fields that represent that resource
+func HookConfigFields(r Resource) map[string]string {
+	resource := r.(*corev2.HookConfig)
+	fields := map[string]string{
+		"hook.name":      resource.ObjectMeta.Name,
+		"hook.namespace": resource.ObjectMeta.Namespace,
+	}
+	stringutil.MergeMapWithPrefix(fields, resource.ObjectMeta.Labels, "hook.labels.")
+	return fields
+}
+
+// PipelineFields returns a set of fields that represent that resource.
+func PipelineFields(r Resource) map[string]string {
+	resource := r.(*corev2.Pipeline)
+	fields := map[string]string{
+		"pipeline.name":      resource.ObjectMeta.Name,
+		"pipeline.namespace": resource.ObjectMeta.Namespace,
+	}
+	stringutil.MergeMapWithPrefix(fields, resource.ObjectMeta.Labels, "pipeline.labels.")
+	return fields
+}
+
+// UserFields returns a set of fields that represent that resource
+func UserFields(r Resource) map[string]string {
+	resource := r.(*corev2.User)
+	return map[string]string{
+		"user.username": resource.Username,
+		"user.disabled": strconv.FormatBool(resource.Disabled),
+		"user.groups":   strings.Join(resource.Groups, ","),
+	}
+}

--- a/v3/fields_funcs.go
+++ b/v3/fields_funcs.go
@@ -1,0 +1,103 @@
+package v3
+
+import (
+	"strconv"
+	"strings"
+
+	corev2 "github.com/sensu/core/v2"
+	"github.com/sensu/core/v3/internal/stringutil"
+)
+
+// APIKeyFields returns a set of fields that represent that resource.
+func APIKeyFields(r Resource) map[string]string {
+	resource := r.(*corev2.APIKey)
+	fields := map[string]string{
+		"api_key.name":     resource.ObjectMeta.Name,
+		"api_key.username": resource.Username,
+	}
+	stringutil.MergeMapWithPrefix(fields, resource.ObjectMeta.Labels, "api_key.labels.")
+	return fields
+}
+
+// AssetFields returns a set of fields that represent that resource
+func AssetFields(r Resource) map[string]string {
+	resource := r.(*corev2.Asset)
+	fields := map[string]string{
+		"asset.name":      resource.ObjectMeta.Name,
+		"asset.namespace": resource.ObjectMeta.Namespace,
+		"asset.filters":   strings.Join(resource.Filters, ","),
+	}
+	stringutil.MergeMapWithPrefix(fields, resource.ObjectMeta.Labels, "asset.labels.")
+	return fields
+}
+
+// CheckConfigFields returns a set of fields that represent that resource
+func CheckConfigFields(r Resource) map[string]string {
+	resource := r.(*corev2.CheckConfig)
+	fields := map[string]string{
+		"check.name":           resource.ObjectMeta.Name,
+		"check.namespace":      resource.ObjectMeta.Namespace,
+		"check.handlers":       strings.Join(resource.Handlers, ","),
+		"check.publish":        strconv.FormatBool(resource.Publish),
+		"check.round_robin":    strconv.FormatBool(resource.RoundRobin),
+		"check.runtime_assets": strings.Join(resource.RuntimeAssets, ","),
+		"check.subscriptions":  strings.Join(resource.Subscriptions, ","),
+	}
+	stringutil.MergeMapWithPrefix(fields, resource.ObjectMeta.Labels, "check.labels.")
+
+	pipelineIDs := []string{}
+	for _, pipeline := range resource.Pipelines {
+		pipelineIDs = append(pipelineIDs, pipeline.ResourceID())
+	}
+	fields["check.pipelines"] = strings.Join(pipelineIDs, ",")
+
+	return fields
+}
+
+// EntityFields returns a set of fields that represent that resource
+func EntityFields(r Resource) map[string]string {
+	resource := r.(*corev2.Entity)
+	fields := map[string]string{
+		"entity.name":          resource.ObjectMeta.Name,
+		"entity.namespace":     resource.ObjectMeta.Namespace,
+		"entity.deregister":    strconv.FormatBool(resource.Deregister),
+		"entity.entity_class":  resource.EntityClass,
+		"entity.subscriptions": strings.Join(resource.Subscriptions, ","),
+	}
+	stringutil.MergeMapWithPrefix(fields, resource.ObjectMeta.Labels, "entity.labels.")
+	return fields
+}
+
+func isSilenced(e *corev2.Event) string {
+	if len(e.Check.Silenced) > 0 {
+		return "true"
+	}
+	return "false"
+}
+
+// EventFields returns a set of fields that represent that resource
+func EventFields(r Resource) map[string]string {
+	resource := r.(*corev2.Event)
+	fields := map[string]string{
+		"event.name":                 resource.ObjectMeta.Name,
+		"event.namespace":            resource.ObjectMeta.Namespace,
+		"event.is_silenced":          isSilenced(resource),
+		"event.check.is_silenced":    isSilenced(resource),
+		"event.check.name":           resource.Check.Name,
+		"event.check.handlers":       strings.Join(resource.Check.Handlers, ","),
+		"event.check.publish":        strconv.FormatBool(resource.Check.Publish),
+		"event.check.round_robin":    strconv.FormatBool(resource.Check.RoundRobin),
+		"event.check.runtime_assets": strings.Join(resource.Check.RuntimeAssets, ","),
+		"event.check.state":          resource.Check.State,
+		"event.check.status":         strconv.Itoa(int(resource.Check.Status)),
+		"event.check.subscriptions":  strings.Join(resource.Check.Subscriptions, ","),
+		"event.entity.deregister":    strconv.FormatBool(resource.Entity.Deregister),
+		"event.entity.name":          resource.Entity.ObjectMeta.Name,
+		"event.entity.entity_class":  resource.Entity.EntityClass,
+		"event.entity.subscriptions": strings.Join(resource.Entity.Subscriptions, ","),
+	}
+	stringutil.MergeMapWithPrefix(fields, resource.ObjectMeta.Labels, "event.labels.")
+	stringutil.MergeMapWithPrefix(fields, resource.Entity.ObjectMeta.Labels, "event.labels.")
+	stringutil.MergeMapWithPrefix(fields, resource.Check.ObjectMeta.Labels, "event.labels.")
+	return fields
+}

--- a/v3/fields_funcs.go
+++ b/v3/fields_funcs.go
@@ -188,3 +188,11 @@ func UserFields(r Resource) map[string]string {
 		"user.groups":   strings.Join(resource.Groups, ","),
 	}
 }
+
+// NamespaceFields returns a set of fields that represent that resource
+func NamespaceFields(r Resource) map[string]string {
+	resource := r.(*Namespace)
+	return map[string]string{
+		"namespace.name": resource.Metadata.Name,
+	}
+}

--- a/v3/fields_funcs.go
+++ b/v3/fields_funcs.go
@@ -196,3 +196,49 @@ func NamespaceFields(r Resource) map[string]string {
 		"namespace.name": resource.Metadata.Name,
 	}
 }
+
+// RoleFields returns a set of fields that represent that resource
+func RoleFields(r Resource) map[string]string {
+	resource := r.(*corev2.Role)
+	fields := map[string]string{
+		"role.name":      resource.ObjectMeta.Name,
+		"role.namespace": resource.ObjectMeta.Namespace,
+	}
+	stringutil.MergeMapWithPrefix(fields, resource.ObjectMeta.Labels, "role.labels.")
+	return fields
+}
+
+// ClusterRoleFields returns a set of fields that represent that resource
+func ClusterRoleFields(r Resource) map[string]string {
+	resource := r.(*corev2.ClusterRole)
+	fields := map[string]string{
+		"clusterrole.name": resource.ObjectMeta.Name,
+	}
+	stringutil.MergeMapWithPrefix(fields, resource.ObjectMeta.Labels, "clusterrole.labels.")
+	return fields
+}
+
+// ClusterRoleBindingFields returns a set of fields that represent that resource
+func ClusterRoleBindingFields(r Resource) map[string]string {
+	resource := r.(*corev2.ClusterRoleBinding)
+	fields := map[string]string{
+		"clusterrolebinding.name":          resource.ObjectMeta.Name,
+		"clusterrolebinding.role_ref.name": resource.RoleRef.Name,
+		"clusterrolebinding.role_ref.type": resource.RoleRef.Type,
+	}
+	stringutil.MergeMapWithPrefix(fields, resource.ObjectMeta.Labels, "clusterrolebinding.labels.")
+	return fields
+}
+
+// RoleBindingFields returns a set of fields that represent that resource
+func RoleBindingFields(r Resource) map[string]string {
+	resource := r.(*corev2.RoleBinding)
+	fields := map[string]string{
+		"rolebinding.name":          resource.ObjectMeta.Name,
+		"rolebinding.namespace":     resource.ObjectMeta.Namespace,
+		"rolebinding.role_ref.name": resource.RoleRef.Name,
+		"rolebinding.role_ref.type": resource.RoleRef.Type,
+	}
+	stringutil.MergeMapWithPrefix(fields, resource.ObjectMeta.Labels, "rolebinding.labels.")
+	return fields
+}

--- a/v3/internal/stringutil/LICENSE
+++ b/v3/internal/stringutil/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2017 Sensu Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/v3/internal/stringutil/map.go
+++ b/v3/internal/stringutil/map.go
@@ -1,0 +1,8 @@
+package stringutil
+
+// Merge contents of one map into another using a prefix.
+func MergeMapWithPrefix(a map[string]string, b map[string]string, prefix string) {
+	for k, v := range b {
+		a[prefix+k] = v
+	}
+}

--- a/v3/internal/stringutil/map_test.go
+++ b/v3/internal/stringutil/map_test.go
@@ -1,0 +1,55 @@
+package stringutil
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMergeMapWithPrefix(t *testing.T) {
+	type args struct {
+		a      map[string]string
+		b      map[string]string
+		prefix string
+	}
+	tests := []struct {
+		name   string
+		args   args
+		expect map[string]string
+	}{
+		{
+			name: "merge empty",
+			args: args{
+				a:      map[string]string{},
+				b:      map[string]string{},
+				prefix: "prefix.",
+			},
+			expect: map[string]string{},
+		},
+		{
+			name: "empty prefix",
+			args: args{
+				a:      map[string]string{"a": "b"},
+				b:      map[string]string{"a": "c"},
+				prefix: "",
+			},
+			expect: map[string]string{"a": "c"},
+		},
+		{
+			name: "with prefix",
+			args: args{
+				a:      map[string]string{"a": "b"},
+				b:      map[string]string{"a": "b"},
+				prefix: "c.",
+			},
+			expect: map[string]string{"a": "b", "c.a": "b"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			MergeMapWithPrefix(tt.args.a, tt.args.b, tt.args.prefix)
+			if !reflect.DeepEqual(tt.args.a, tt.expect) {
+				t.Errorf("MergeMapWithPrefix() = %#v, want %#v", tt.args.a, tt.expect)
+			}
+		})
+	}
+}

--- a/v3/internal/stringutil/occurrences.go
+++ b/v3/internal/stringutil/occurrences.go
@@ -1,0 +1,60 @@
+package stringutil
+
+// OccurrencesOf returns the number of times a string appears in the given slice
+// of strings.
+func OccurrencesOf(s string, in []string) int {
+	o := NewOccurrenceSet(in...)
+	return o.Get(s)
+}
+
+// OccurrenceSet captures of occurrences of string values.
+type OccurrenceSet map[string]int
+
+// NewOccurrenceSet returns new instance of OccurrenceSet.
+func NewOccurrenceSet(s ...string) OccurrenceSet {
+	o := OccurrenceSet{}
+	o.Add(s...)
+	return o
+}
+
+// Add entry and increment count
+func (o OccurrenceSet) Add(ss ...string) {
+	for _, s := range ss {
+		num := o[s]
+		o[s] = num + 1
+	}
+}
+
+// Remove items from set
+func (o OccurrenceSet) Remove(ss ...string) {
+	for _, s := range ss {
+		delete(o, s)
+	}
+}
+
+// Get returns occurrences of given string
+func (o OccurrenceSet) Get(entry string) int {
+	return o[entry]
+}
+
+// Values returns all occurrences
+func (o OccurrenceSet) Values() []string {
+	vs := []string{}
+	for v := range o {
+		vs = append(vs, v)
+	}
+	return vs
+}
+
+// Merge given set of occurrences
+func (o OccurrenceSet) Merge(b OccurrenceSet) {
+	for name, bCount := range b {
+		aCount := o[name]
+		o[name] = aCount + bCount
+	}
+}
+
+// Size of values tracked
+func (o OccurrenceSet) Size() int {
+	return len(o)
+}

--- a/v3/internal/stringutil/occurrences_test.go
+++ b/v3/internal/stringutil/occurrences_test.go
@@ -1,0 +1,45 @@
+package stringutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOccurrences(t *testing.T) {
+	assert := assert.New(t)
+
+	// new
+	setA := NewOccurrenceSet("one", "two")
+	assert.Equal(setA.Size(), 2)
+	assert.Contains(setA.Values(), "one")
+	assert.Contains(setA.Values(), "two")
+
+	// add
+	setB := setA
+	setB.Add("three")
+	setB.Add("four")
+	assert.Equal(setB.Size(), 4)
+	assert.Contains(setB.Values(), "three")
+	assert.Contains(setB.Values(), "four")
+
+	// merge
+	setA.Merge(setB)
+	assert.Equal(setA.Size(), 4)
+	assert.Contains(setA.Values(), "three")
+	assert.Contains(setA.Values(), "four")
+
+	// remove
+	setA.Remove("four")
+	assert.Equal(setA.Size(), 3)
+	assert.NotContains(setA.Values(), "four")
+}
+
+func TestOccurrencesOf(t *testing.T) {
+	assert := assert.New(t)
+
+	assert.Equal(OccurrencesOf("zero", []string{}), 0)
+	assert.Equal(OccurrencesOf("zero", []string{"one", "one", "four"}), 0)
+	assert.Equal(OccurrencesOf("one", []string{"one", "two", "three"}), 1)
+	assert.Equal(OccurrencesOf("two", []string{"two", "two", "three"}), 2)
+}

--- a/v3/internal/stringutil/strings.go
+++ b/v3/internal/stringutil/strings.go
@@ -1,0 +1,105 @@
+package stringutil
+
+import (
+	"strings"
+	"unicode"
+)
+
+const (
+	lowerAlphaStart = 97
+	lowerAlphaStop  = 122
+)
+
+// InArray searches 'array' for 'item' string
+// Returns true 'item' is a value of 'array'
+func InArray(item string, array []string) bool {
+	if item == "" || len(array) == 0 {
+		return false
+	}
+
+	for i := range array {
+		if array[i] == item {
+			return true
+		}
+	}
+
+	return false
+}
+
+func isAlpha(r rune) bool {
+	return r >= lowerAlphaStart && r <= lowerAlphaStop
+}
+
+func alphaNumeric(s string) bool {
+	for _, r := range s {
+		if !(unicode.IsDigit(r) || isAlpha(r)) {
+			return false
+		}
+	}
+	return true
+}
+
+func normalize(s string) string {
+	if alphaNumeric(s) {
+		return s
+	}
+	lowered := strings.ToLower(s)
+	if alphaNumeric(lowered) {
+		return lowered
+	}
+	trimmed := make([]rune, 0, len(lowered))
+	for _, r := range lowered {
+		if isAlpha(r) {
+			trimmed = append(trimmed, r)
+		}
+	}
+	return string(trimmed)
+}
+
+// FoundInArray searches array for item without distinguishing between uppercase
+// and lowercase and non-alphanumeric characters. Returns true if item is a
+// value of array
+func FoundInArray(item string, array []string) bool {
+	if item == "" || len(array) == 0 {
+		return false
+	}
+
+	item = normalize(item)
+
+	for i := range array {
+		if normalize(array[i]) == item {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Remove searches 'array' for 'item' string
+// and removes the string if found
+func Remove(item string, array []string) []string {
+	for i, v := range array {
+		if v == item {
+			array = append(array[:i], array[i+1:]...)
+			break
+		}
+	}
+	return array
+}
+
+// Intersect finds the intersection between two slices of strings.
+func Intersect(a []string, b []string) []string {
+	set := make([]string, 0, len(a))
+	tab := map[string]bool{}
+
+	for _, e := range a {
+		tab[e] = true
+	}
+
+	for _, e := range b {
+		if _, found := tab[e]; found {
+			set = append(set, e)
+		}
+	}
+	return set
+}

--- a/v3/internal/stringutil/strings_test.go
+++ b/v3/internal/stringutil/strings_test.go
@@ -1,0 +1,84 @@
+package stringutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInArray(t *testing.T) {
+	var item string
+	var array []string
+
+	found := InArray(item, array)
+	assert.False(t, found, "if item and array are both empty, it should return false")
+
+	item = "foo"
+	found = InArray(item, array)
+	assert.False(t, found, "if array is empty, it should return false")
+
+	array = []string{"bar", "qux"}
+	found = InArray(item, array)
+	assert.False(t, found, "it should return false if the item isn't found in the array")
+
+	array = append(array, "foo")
+	found = InArray(item, array)
+	assert.True(t, found, "it should return true if the item is found in the array")
+}
+
+func TestFindInArray(t *testing.T) {
+	var array []string
+
+	found := FoundInArray("Foo", []string{})
+	assert.False(t, found)
+
+	array = []string{"foo", "bar"}
+	found = FoundInArray("Foo", array)
+	assert.True(t, found)
+
+	array = []string{"foo", "bar"}
+	found = FoundInArray("FooBar", array)
+	assert.False(t, found)
+
+	array = []string{"foo", "bar"}
+	found = FoundInArray("Foo ", array)
+	assert.True(t, found)
+
+	array = []string{"foo_bar"}
+	found = FoundInArray("Foo_Bar", array)
+	assert.True(t, found)
+
+	array = []string{"foobar"}
+	found = FoundInArray("Foo_Qux", array)
+	assert.False(t, found)
+}
+
+func TestRemove(t *testing.T) {
+	array := []string{"bar", "qux"}
+	array = Remove("bar", array)
+	assert.Equal(t, []string{"qux"}, array)
+
+	array = []string{}
+	array = Remove("bar", array)
+	assert.Equal(t, []string{}, array)
+}
+
+func TestIntersect(t *testing.T) {
+	a, b := []string{"bar", "qux"}, []string{"foo", "bar"}
+	intr := Intersect(a, b)
+	assert.Equal(t, []string{"bar"}, intr)
+
+	a, b = []string{}, []string{}
+	intr = Intersect(a, b)
+	assert.Equal(t, []string{}, intr)
+
+	a, b = []string{"foo", "qux"}, []string{"baz", "bar"}
+	intr = Intersect(a, b)
+	assert.Equal(t, []string{}, intr)
+}
+
+func BenchmarkFoundInArray(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		FoundInArray("foo!BAR   baz", []string{"foo", "foobar", "FOO BAR", "foo bar baz", "foobarbaz"})
+	}
+}


### PR DESCRIPTION
These fields funcs extract properties to be filtered on. They're used by the graphql layer and need to take core/v3 resources instead of core/v2. Otherwise they're just basic copies of the FieldsFuncs found in core/v2.