### PR TITLE
remove use of deprecated method BuildNameToCertificate

### DIFF
--- a/v2/tls.go
+++ b/v2/tls.go
@@ -15,11 +15,13 @@ var (
 	// CBC suites (Lucky13 attack) this means TLS 1.1 can't work (no GCM)
 	// additionally, we should only use perfect forward secrecy ciphers
 	DefaultCipherSuites = []uint16{
+		// These ciphers are strong and fast on hardware with AES-IN.
+		// These are re-ordered from the go default for an improved security posture
 		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
 		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
 		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
 		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-		// these ciphers require go 1.8+
+		// These ciphers are strong, fast, and do not require hardware AES-NI.
 		tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
 		tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
 	}
@@ -56,10 +58,6 @@ func (t *TLSOptions) ToServerTLSConfig() (*tls.Config, error) {
 
 		cfg.Certificates = []tls.Certificate{cert}
 	}
-
-	// useful when we present multiple certificates
-	//nolint:staticcheck // ignore SA1019 for old code
-	cfg.BuildNameToCertificate()
 
 	// apply hardened TLS settings
 	cfg.MinVersion = tlsMinVersion


### PR DESCRIPTION
I don't believe that this deprecated function is useful to use anymore. Certificate matching on common names fell out of favour ages ago, and it has been many years since global CAs have been issuing proper certs with Subject-Alternate-Names. Also it only allows associating a single certificate with a  name (use case could be having both an RSA and EC certificate for the same name)

```
// BuildNameToCertificate parses c.Certificates and builds c.NameToCertificate
// from the CommonName and SubjectAlternateName fields of each of the leaf
// certificates.
//
// Deprecated: NameToCertificate only allows associating a single certificate
// with a given name. Leave that field nil to let the library select the first
// compatible chain from Certificates.
func (c *Config) BuildNameToCertificate() {
	c.NameToCertificate = make(map[string]*Certificate)
	for i := range c.Certificates {
		cert := &c.Certificates[i]
		x509Cert, err := cert.leaf()
		if err != nil {
			continue
		}
		// If SANs are *not* present, some clients will consider the certificate
		// valid for the name in the Common Name.
		if x509Cert.Subject.CommonName != "" && len(x509Cert.DNSNames) == 0 {
			c.NameToCertificate[x509Cert.Subject.CommonName] = cert
		}
		for _, san := range x509Cert.DNSNames {
			c.NameToCertificate[san] = cert
		}
	}
}
```
