### PR TITLE
Relax APIKey name validation

### DIFF
--- a/v2/apikey.go
+++ b/v2/apikey.go
@@ -5,7 +5,6 @@ import (
 	"net/url"
 	"path"
 
-	"github.com/google/uuid"
 	stringsutil "github.com/sensu/core/v2/internal/stringutil"
 )
 
@@ -38,10 +37,6 @@ func (a *APIKey) Validate() error {
 
 	if a.Username == "" {
 		return fmt.Errorf("api key must have a username")
-	}
-
-	if _, err := uuid.Parse(a.Name); err != nil {
-		return fmt.Errorf("api key name: %s", err)
 	}
 
 	return nil

--- a/v2/apikey.go
+++ b/v2/apikey.go
@@ -15,7 +15,8 @@ const (
 
 // APIKeyResponse is returned by the Sensu 7.x apikeys API
 type APIKeyResponse struct {
-	Key string `json:"key"`
+	Name string `json:"name"`
+	Key  string `json:"key"`
 }
 
 // StorePrefix returns the path prefix to this resource in the store.

--- a/v2/apikey_test.go
+++ b/v2/apikey_test.go
@@ -27,16 +27,6 @@ func TestAPIKeyValidate(t *testing.T) {
 	assert.Error(t, a.Validate())
 	a.Username = "bar"
 
-	// Empty name
-	assert.Error(t, a.Validate())
-	a.Name = "foo"
-
-	// Invalid name
-	assert.Error(t, a.Validate())
-	a.Name = "226f9e06-9d54-45c6-a9f6-4206bfa7ccf6"
-
-	assert.NoError(t, a.Validate())
-	assert.Equal(t, "226f9e06-9d54-45c6-a9f6-4206bfa7ccf6", a.Name)
 	assert.Equal(t, "bar", a.Username)
 	assert.Equal(t, "", a.Namespace)
 }


### PR DESCRIPTION
Required for Sensu 7.x, probably fine for Sensu 6.x as well.